### PR TITLE
Update to the latest

### DIFF
--- a/video11_1_Installing Q#/QB4.qs
+++ b/video11_1_Installing Q#/QB4.qs
@@ -7,7 +7,6 @@
 	@EntryPoint()
 	operation QB4Run () : Unit
     {
-	
 		mutable num0000 = 0;
 		mutable num0001 = 0;
 		mutable num0010 = 0;
@@ -25,9 +24,9 @@
 		mutable num1110 = 0;
 		mutable num1111 = 0;
 
-		using (qubits = Qubit[4])
+		use qubits = Qubit[4]
 		{
-			for (test in 1..10000)
+			for test in 1..10000
 			{
 				Set (Zero, qubits[0]);
 				Set (Zero, qubits[1]);
@@ -111,8 +110,6 @@
 				if(res3 == One  and res2 == One  and res1 == Zero and res0 == One ){set num1101 = num1101 + 1;}
 				if(res3 == One  and res2 == One  and res1 == One  and res0 == Zero){set num1110 = num1110 + 1;}
 				if(res3 == One  and res2 == One  and res1 == One  and res0 == One ){set num1111 = num1111 + 1;}
-				
-				
 			}
 			Set(Zero, qubits[0]);
 			Set(Zero, qubits[1]);

--- a/video11_1_Installing Q#/qc101project.csproj
+++ b/video11_1_Installing Q#/qc101project.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20072031">
+<Project Sdk="Microsoft.Quantum.Sdk/0.28.302812">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
1. Syntax to eliminate warnings like:
```
QB4.qs(28,7): warning QS3306: Deprecated syntax. Parentheses here are no longer required and will not
be supported in the future.
```

2. Update Quantum SDK version.